### PR TITLE
Update conv11 for 1x1 convolution

### DIFF
--- a/conv11/conv11_bias_input.v
+++ b/conv11/conv11_bias_input.v
@@ -1,4 +1,4 @@
-module conv33_bias_input #(
+module conv11_bias_input #(
     parameter BIAS_WIDTH = 32
 )(
     input  wire                  clk,

--- a/conv11/conv11_calc.v
+++ b/conv11/conv11_calc.v
@@ -1,4 +1,4 @@
-module conv33_calc #(
+module conv11_calc #(
     parameter DATA_WIDTH = 8,
     parameter MUL_WIDTH  = 16,
     parameter BIAS_WIDTH = 32,
@@ -6,110 +6,40 @@ module conv33_calc #(
 )(
     input  wire                   clk,
     input  wire                   rst,
-    input  wire                   conv33_en,
+    input  wire                   conv11_en,
 
     // 输入数据
     input  wire signed [DATA_WIDTH-1:0]  data_0_0,
-    input  wire signed [DATA_WIDTH-1:0]  data_0_1,
-    input  wire signed [DATA_WIDTH-1:0]  data_0_2,
-    input  wire signed [DATA_WIDTH-1:0]  data_1_0,
-    input  wire signed [DATA_WIDTH-1:0]  data_1_1,
-    input  wire signed [DATA_WIDTH-1:0]  data_1_2,
-    input  wire signed [DATA_WIDTH-1:0]  data_2_0,
-    input  wire signed [DATA_WIDTH-1:0]  data_2_1,
-    input  wire signed [DATA_WIDTH-1:0]  data_2_2,
 
     // 卷积权重
     input  wire signed [DATA_WIDTH-1:0]  weight_0,
-    input  wire signed [DATA_WIDTH-1:0]  weight_1,
-    input  wire signed [DATA_WIDTH-1:0]  weight_2,
-    input  wire signed [DATA_WIDTH-1:0]  weight_3,
-    input  wire signed [DATA_WIDTH-1:0]  weight_4,
-    input  wire signed [DATA_WIDTH-1:0]  weight_5,
-    input  wire signed [DATA_WIDTH-1:0]  weight_6,
-    input  wire signed [DATA_WIDTH-1:0]  weight_7,
-    input  wire signed [DATA_WIDTH-1:0]  weight_8,
 
-    // 偏置 
-    input  wire signed [BIAS_WIDTH-1:0] bias,
+    // 偏置
+    input  wire signed [BIAS_WIDTH-1:0]  bias,
 
     // 缩放系数
-    input  wire signed [BIAS_WIDTH-1:0] scale,
+    input  wire signed [BIAS_WIDTH-1:0]  scale,
 
     // 输出结果
     output reg  signed [DATA_WIDTH-1:0] result,
-    output reg                          valid,
-    
-    output wire signed [MUL_WIDTH-1:0] mul_0,
-    output wire signed [MUL_WIDTH-1:0] mul_1,
-    output wire signed [MUL_WIDTH-1:0] mul_2,
-    output wire signed [MUL_WIDTH-1:0] mul_3,
-    output wire signed [MUL_WIDTH-1:0] mul_4,
-    output wire signed [MUL_WIDTH-1:0] mul_5,
-    output wire signed [MUL_WIDTH-1:0] mul_6,
-    output wire signed [MUL_WIDTH-1:0] mul_7,
-    output wire signed [MUL_WIDTH-1:0] mul_8,
-    output wire signed [MUL_WIDTH:0]   sum0,
-    output wire signed [MUL_WIDTH:0]   sum1, 
-    output wire signed [MUL_WIDTH:0]   sum2,
-    output wire signed [MUL_WIDTH:0]   sum3,
-    output wire signed [MUL_WIDTH+1:0] sum4,
-    output wire signed [MUL_WIDTH+1:0] sum5
+    output reg                          valid
 );
 
-    assign mul_0 = mul[0];
-    assign mul_1 = mul[1];
-    assign mul_2 = mul[2];
-    assign mul_3 = mul[3];
-    assign mul_4 = mul[4];
-    assign mul_5 = mul[5];
-    assign mul_6 = mul[6];
-    assign mul_7 = mul[7];
-    assign mul_8 = mul[8];
-    assign sum0= sum_0;
-    assign sum1= sum_1; 
-    assign sum2= sum_2;
-    assign sum3= sum_3;
-    assign sum4= sum_4;
-    assign sum5= sum_5;
-
-    // 中间乘法结果
-    wire signed [MUL_WIDTH-1:0] mul [0:8];
-
-    assign mul[0] = data_0_0 * weight_0;
-    assign mul[1] = data_0_1 * weight_1;
-    assign mul[2] = data_0_2 * weight_2;
-    assign mul[3] = data_1_0 * weight_3;
-    assign mul[4] = data_1_1 * weight_4;
-    assign mul[5] = data_1_2 * weight_5;
-    assign mul[6] = data_2_0 * weight_6;
-    assign mul[7] = data_2_1 * weight_7;
-    assign mul[8] = data_2_2 * weight_8;
-
-    // 分级加法树（后期模块化）
-    wire signed [MUL_WIDTH:0] sum_0 = mul[0] + mul[1];
-    wire signed [MUL_WIDTH:0] sum_1 = mul[2] + mul[3];
-    wire signed [MUL_WIDTH:0] sum_2 = mul[4] + mul[5];
-    wire signed [MUL_WIDTH:0] sum_3 = mul[6] + mul[7];
-    wire signed [MUL_WIDTH+1:0] sum_4 = sum_0 + sum_1;  // 0~3
-    wire signed [MUL_WIDTH+1:0] sum_5 = sum_2 + sum_3;  // 4~7
-    wire signed [OUT_WIDTH-1:0] conv_sum = sum_4 + sum_5 + mul[8];  // 0~8;
-    wire signed [OUT_WIDTH-1:0] result_bias <= conv_sum + bias;
+    wire signed [MUL_WIDTH-1:0] mul = data_0_0 * weight_0;
+    wire signed [OUT_WIDTH-1:0] result_bias = mul + bias;
     wire signed [OUT_WIDTH-1:0] result_scale = result_bias * scale;
-    wire signed [DATA_WIDTH-1:0] result_8 <= result_scale[23:16];
+    wire signed [DATA_WIDTH-1:0] result_8 = result_scale[23:16];
 
-    // 同步输出
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             result <= 0;
             valid  <= 0;
-        end else if (conv33_en) begin
-            result  <= result_8[DATA_WIDTH-1] ? 0 : result_8;
+        end else if (conv11_en) begin
+            result <= result_8[DATA_WIDTH-1] ? 0 : result_8;
             valid  <= 1;
         end else begin
             valid <= 0;
         end
     end
-
 
 endmodule

--- a/conv11/conv11_ctrl.v
+++ b/conv11/conv11_ctrl.v
@@ -1,8 +1,8 @@
-// conv33_ctrl.v
-// 控制 3x3 卷积模块整体流程：依次加载权重�?�偏置和输入数据�?
+// conv11_ctrl.v
+// 控制 1x1 卷积模块整体流程：依次加载权重�?�偏置和输入数据�?
 // 然后启动计算并在结果输出后重新回到空闲状态�??
 
-module conv33_ctrl (
+module conv11_ctrl (
     input  wire clk,
     input  wire rst,
 
@@ -25,7 +25,7 @@ module conv33_ctrl (
 
     output reg  inputbuf_read_en,
 
-    output reg  conv33_en,
+    output reg  conv11_en,
     output reg  output_en
 );
 
@@ -73,7 +73,7 @@ module conv33_ctrl (
         load_scale_en  = 0;
         read_scale_en  = 0;
         inputbuf_read_en  = 0;
-        conv33_en      = 0;
+        conv11_en      = 0;
         output_en      = 0;
 
         case (state)
@@ -93,7 +93,7 @@ module conv33_ctrl (
                 inputbuf_read_en = 1;
             end
             COMPUTE: begin
-                conv33_en = 1;             // 触发计算
+                conv11_en = 1;             // 触发计算
             end
             OUTPUT: begin
                 output_en = 1;             // 启动结果输出

--- a/conv11/conv11_input.v
+++ b/conv11/conv11_input.v
@@ -1,4 +1,4 @@
-module conv33_input #(
+module conv11_input #(
     parameter DATA_WIDTH = 8
 )(
     input  wire clk,
@@ -8,37 +8,19 @@ module conv33_input #(
     input  wire input_valid,
     input  wire inputbuf_read_en,
     input  wire [DATA_WIDTH-1:0] in_0_0,
-    input  wire [DATA_WIDTH-1:0] in_0_1,
-    input  wire [DATA_WIDTH-1:0] in_0_2,
-    input  wire [DATA_WIDTH-1:0] in_1_0,
-    input  wire [DATA_WIDTH-1:0] in_1_1,
-    input  wire [DATA_WIDTH-1:0] in_1_2,
-    input  wire [DATA_WIDTH-1:0] in_2_0,
-    input  wire [DATA_WIDTH-1:0] in_2_1,
-    input  wire [DATA_WIDTH-1:0] in_2_2,
 
     // 输出给卷积计算模块
     output wire [DATA_WIDTH-1:0] out_0_0,
-    output wire [DATA_WIDTH-1:0] out_0_1,
-    output wire [DATA_WIDTH-1:0] out_0_2,
-    output wire [DATA_WIDTH-1:0] out_1_0,
-    output wire [DATA_WIDTH-1:0] out_1_1,
-    output wire [DATA_WIDTH-1:0] out_1_2,
-    output wire [DATA_WIDTH-1:0] out_2_0,
-    output wire [DATA_WIDTH-1:0] out_2_1,
-    output wire [DATA_WIDTH-1:0] out_2_2,
 
     // 控制信号输出
     output wire input_ready
-
 );
 
     // 中间信号
     wire inputbuf_load;
 
-
     // 数据缓存模块实例化
-    conv33_input_buffer #(
+    conv11_input_buffer #(
         .DATA_WIDTH(DATA_WIDTH)
     ) u_input_buffer (
         .clk(clk),
@@ -46,16 +28,12 @@ module conv33_input #(
         .input_valid(input_valid),
         .inputbuf_read_en(inputbuf_read_en),
         .inputbuf_load(inputbuf_load),
-        .in_0_0(in_0_0), .in_0_1(in_0_1), .in_0_2(in_0_2),
-        .in_1_0(in_1_0), .in_1_1(in_1_1), .in_1_2(in_1_2),
-        .in_2_0(in_2_0), .in_2_1(in_2_1), .in_2_2(in_2_2),
-        .out_0_0(out_0_0), .out_0_1(out_0_1), .out_0_2(out_0_2),
-        .out_1_0(out_1_0), .out_1_1(out_1_1), .out_1_2(out_1_2),
-        .out_2_0(out_2_0), .out_2_1(out_2_1), .out_2_2(out_2_2)
+        .in_0_0(in_0_0),
+        .out_0_0(out_0_0)
     );
 
     // 控制模块实例化
-    conv33_input_ctrl u_input_ctrl (
+    conv11_input_ctrl u_input_ctrl (
         .clk(clk),
         .rst(rst),
         .input_valid(input_valid),

--- a/conv11/conv11_input_buffer.v
+++ b/conv11/conv11_input_buffer.v
@@ -1,4 +1,4 @@
-module conv33_input_buffer #(
+module conv11_input_buffer #(
     parameter DATA_WIDTH = 8
 )(
     input wire clk,
@@ -6,41 +6,20 @@ module conv33_input_buffer #(
 
     input wire input_valid,
     input wire [DATA_WIDTH-1:0] in_0_0,
-    input wire [DATA_WIDTH-1:0] in_0_1,
-    input wire [DATA_WIDTH-1:0] in_0_2,
-    input wire [DATA_WIDTH-1:0] in_1_0,
-    input wire [DATA_WIDTH-1:0] in_1_1,
-    input wire [DATA_WIDTH-1:0] in_1_2,
-    input wire [DATA_WIDTH-1:0] in_2_0,
-    input wire [DATA_WIDTH-1:0] in_2_1,
-    input wire [DATA_WIDTH-1:0] in_2_2,
 
     input wire inputbuf_read_en,
 
     output reg [DATA_WIDTH-1:0] out_0_0,
-    output reg [DATA_WIDTH-1:0] out_0_1,
-    output reg [DATA_WIDTH-1:0] out_0_2,
-    output reg [DATA_WIDTH-1:0] out_1_0,
-    output reg [DATA_WIDTH-1:0] out_1_1,
-    output reg [DATA_WIDTH-1:0] out_1_2,
-    output reg [DATA_WIDTH-1:0] out_2_0,
-    output reg [DATA_WIDTH-1:0] out_2_1,
-    output reg [DATA_WIDTH-1:0] out_2_2,
-
     output reg inputbuf_load
 );
 
-    reg [DATA_WIDTH-1:0] buf_0_0, buf_0_1, buf_0_2;
-    reg [DATA_WIDTH-1:0] buf_1_0, buf_1_1, buf_1_2;
-    reg [DATA_WIDTH-1:0] buf_2_0, buf_2_1, buf_2_2;
+    reg [DATA_WIDTH-1:0] buf_0_0;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             inputbuf_load <= 0;
         end else if (input_valid) begin
-            buf_0_0 <= in_0_0; buf_0_1 <= in_0_1; buf_0_2 <= in_0_2;
-            buf_1_0 <= in_1_0; buf_1_1 <= in_1_1; buf_1_2 <= in_1_2;
-            buf_2_0 <= in_2_0; buf_2_1 <= in_2_1; buf_2_2 <= in_2_2;
+            buf_0_0 <= in_0_0;
             inputbuf_load <= 1;
         end else if (inputbuf_read_en) begin
             inputbuf_load <= 0;
@@ -48,11 +27,8 @@ module conv33_input_buffer #(
     end
 
     always @(posedge clk) begin
-        if (inputbuf_read_en) begin
-            out_0_0 <= buf_0_0; out_0_1 <= buf_0_1; out_0_2 <= buf_0_2;
-            out_1_0 <= buf_1_0; out_1_1 <= buf_1_1; out_1_2 <= buf_1_2;
-            out_2_0 <= buf_2_0; out_2_1 <= buf_2_1; out_2_2 <= buf_2_2;
-        end
+        if (inputbuf_read_en)
+            out_0_0 <= buf_0_0;
     end
 
 endmodule

--- a/conv11/conv11_input_ctrl.v
+++ b/conv11/conv11_input_ctrl.v
@@ -1,4 +1,4 @@
-module conv33_input_ctrl (
+module conv11_input_ctrl (
     input wire clk,
     input wire rst,
     input wire input_valid,

--- a/conv11/conv11_output.v
+++ b/conv11/conv11_output.v
@@ -1,4 +1,4 @@
-module conv33_output #(
+module conv11_output #(
     parameter OUT_WIDTH = 8
 )(
     input  wire clk,
@@ -18,7 +18,7 @@ module conv33_output #(
     wire output_valid;
 
     // 输出缓存
-    conv33_output_buffer #(
+    conv11_output_buffer #(
         .OUT_WIDTH(OUT_WIDTH)
     ) u_output_buffer (
         .clk(clk),
@@ -31,7 +31,7 @@ module conv33_output #(
     );
 
     // 输出控制器
-    conv33_output_ctrl u_output_ctrl (
+    conv11_output_ctrl u_output_ctrl (
         .clk(clk),
         .rst(rst),
         .in_valid(in_valid),

--- a/conv11/conv11_output_buffer.v
+++ b/conv11/conv11_output_buffer.v
@@ -1,4 +1,4 @@
-module conv33_output_buffer #(
+module conv11_output_buffer #(
     parameter OUT_WIDTH = 8
 )(
     input wire clk,

--- a/conv11/conv11_output_ctrl.v
+++ b/conv11/conv11_output_ctrl.v
@@ -1,4 +1,4 @@
-module conv33_output_ctrl (
+module conv11_output_ctrl (
     input wire clk,
     input wire rst,
 

--- a/conv11/conv11_scale_input.v
+++ b/conv11/conv11_scale_input.v
@@ -1,4 +1,4 @@
-module conv33_scale_input #(
+module conv11_scale_input #(
     parameter SCALE_WIDTH = 24
 )(
     input  wire                  clk,

--- a/conv11/conv11_weight_input.v
+++ b/conv11/conv11_weight_input.v
@@ -1,4 +1,4 @@
-module conv33_weight_input #(
+module conv11_weight_input #(
     parameter DATA_WIDTH = 8
 )(
     input  wire                   clk,
@@ -11,56 +11,40 @@ module conv33_weight_input #(
     // 输出控制
     input  wire                   read_en,
 
-    // 输出权重（并行 9 个）
+    // 输出权重
     output reg  [DATA_WIDTH-1:0]  weight_0,
-    output reg  [DATA_WIDTH-1:0]  weight_1,
-    output reg  [DATA_WIDTH-1:0]  weight_2,
-    output reg  [DATA_WIDTH-1:0]  weight_3,
-    output reg  [DATA_WIDTH-1:0]  weight_4,
-    output reg  [DATA_WIDTH-1:0]  weight_5,
-    output reg  [DATA_WIDTH-1:0]  weight_6,
-    output reg  [DATA_WIDTH-1:0]  weight_7,
-    output reg  [DATA_WIDTH-1:0]  weight_8,
-
     output reg                    weight_load,  // 加载完成标志
     output reg                    valid         // 输出权重有效标志
 );
 
-    reg [DATA_WIDTH-1:0] buffer [0:8];
-    reg [3:0] load_cnt;
+    reg [DATA_WIDTH-1:0] buffer;
+    reg loaded;
 
-    // 权重加载（串行）
+    // 权重加载（串行，只有一个权重）
     always @(posedge clk) begin
         if (rst) begin
-            load_cnt    <= 0;
+            buffer      <= 0;
+            loaded      <= 0;
             weight_load <= 0;
-        end else if (load_en && load_cnt < 9) begin
-            buffer[load_cnt] <= load_data;
-            load_cnt <= load_cnt + 1;
-
-            if (load_cnt == 8)
-                weight_load <= 1; 
-            else
-                weight_load <= 0;
+        end else if (load_en && !loaded) begin
+            buffer      <= load_data;
+            loaded      <= 1;
+            weight_load <= 1;
         end else begin
             weight_load <= 0;  // 默认拉低（1拍脉冲）
         end
     end
 
-    // 并行输出
+    // 输出权重
     always @(posedge clk or posedge rst) begin
         if (rst) begin
-            weight_0 <= 0; weight_1 <= 0; weight_2 <= 0;
-            weight_3 <= 0; weight_4 <= 0; weight_5 <= 0;
-            weight_6 <= 0; weight_7 <= 0; weight_8 <= 0;
+            weight_0 <= 0;
             valid    <= 0;
         end else if (read_en) begin
-            weight_0 <= buffer[0]; weight_1 <= buffer[1]; weight_2 <= buffer[2];
-            weight_3 <= buffer[3]; weight_4 <= buffer[4]; weight_5 <= buffer[5];
-            weight_6 <= buffer[6]; weight_7 <= buffer[7]; weight_8 <= buffer[8];
+            weight_0 <= buffer;
             valid    <= 1;
         end else begin
-            valid    <= 0;
+            valid <= 0;
         end
     end
 

--- a/conv11/conv11v
+++ b/conv11/conv11v
@@ -1,4 +1,4 @@
-module conv33 #(
+module conv11 #(
     parameter DATA_WIDTH = 8,
     parameter BIAS_WIDTH = 32,
     parameter MUL_WIDTH  = 16,
@@ -14,15 +14,7 @@ module conv33 #(
 
     // 输入数据
     input  wire                   input_valid,
-    input  wire [DATA_WIDTH-1:0]  in_0_0,
-    input  wire [DATA_WIDTH-1:0]  in_0_1,
-    input  wire [DATA_WIDTH-1:0]  in_0_2,
-    input  wire [DATA_WIDTH-1:0]  in_1_0,
-    input  wire [DATA_WIDTH-1:0]  in_1_1,
-    input  wire [DATA_WIDTH-1:0]  in_1_2,
-    input  wire [DATA_WIDTH-1:0]  in_2_0,
-    input  wire [DATA_WIDTH-1:0]  in_2_1,
-    input  wire [DATA_WIDTH-1:0]  in_2_2,
+    input  wire [DATA_WIDTH-1:0]  in_data,
 
     // 卷积结果
     output wire                   out_valid,
@@ -37,7 +29,7 @@ module conv33 #(
     wire load_scale_en;
     wire read_scale_en;
     wire inputbuf_read_en;
-    wire conv33_en;
+    wire conv11_en;
     wire output_en;
 
     // 状态信号
@@ -49,7 +41,7 @@ module conv33 #(
     wire output_done;
 
     // 权重缓存
-    wire [DATA_WIDTH-1:0] w0, w1, w2, w3, w4, w5, w6, w7, w8;
+    wire [DATA_WIDTH-1:0] w0;
     wire                  weight_valid;
     // 偏置缓存
     wire [BIAS_WIDTH-1:0] bias;
@@ -59,10 +51,10 @@ module conv33 #(
     wire                  scale_valid;
 
     // 输入数据缓存
-    wire [DATA_WIDTH-1:0] d00, d01, d02, d10, d11, d12, d20, d21, d22;
+    wire [DATA_WIDTH-1:0] d00;
 
     // 控制模块
-    conv33_ctrl u_ctrl(
+    conv11_ctrl u_ctrl(
         .clk                (clk),
         .rst                (rst),
         .weight_load_done   (weight_load_done),
@@ -78,12 +70,12 @@ module conv33 #(
         .load_scale_en      (load_scale_en),
         .read_scale_en      (read_scale_en),
         .inputbuf_read_en   (inputbuf_read_en),
-        .conv33_en          (conv33_en),
+        .conv11_en          (conv11_en),
         .output_en          (output_en)
     );
 
     // 权重模块
-    conv33_weight_input #(
+    conv11_weight_input #(
         .DATA_WIDTH(DATA_WIDTH)
     ) u_weight_input(
         .clk        (clk),
@@ -92,20 +84,12 @@ module conv33 #(
         .load_data  (weight_data),
         .read_en    (read_weight_en),
         .weight_0   (w0),
-        .weight_1   (w1),
-        .weight_2   (w2),
-        .weight_3   (w3),
-        .weight_4   (w4),
-        .weight_5   (w5),
-        .weight_6   (w6),
-        .weight_7   (w7),
-        .weight_8   (w8),
         .weight_load(weight_load_done),
         .valid      (weight_valid)
     );
 
     // 偏置模块
-    conv33_bias_input #(
+    conv11_bias_input #(
         .BIAS_WIDTH(BIAS_WIDTH)
     ) u_bias_input(
         .clk      (clk),
@@ -119,7 +103,7 @@ module conv33 #(
     );
 
     // 缩放系数模块
-    conv33_scale_input #(
+    conv11_scale_input #(
         .SCALE_WIDTH(BIAS_WIDTH)
     ) u_scale_input(
         .clk      (clk),
@@ -133,30 +117,14 @@ module conv33 #(
     );
 
     // 输入模块
-    conv33_input #(
+    conv11_input #(
         .DATA_WIDTH(DATA_WIDTH)
     ) u_input(
         .clk     (clk),
         .rst     (rst),
         .input_valid(input_valid),
-        .in_0_0  (in_0_0),
-        .in_0_1  (in_0_1),
-        .in_0_2  (in_0_2),
-        .in_1_0  (in_1_0),
-        .in_1_1  (in_1_1),
-        .in_1_2  (in_1_2),
-        .in_2_0  (in_2_0),
-        .in_2_1  (in_2_1),
-        .in_2_2  (in_2_2),
+        .in_0_0  (in_data),
         .out_0_0 (d00),
-        .out_0_1 (d01),
-        .out_0_2 (d02),
-        .out_1_0 (d10),
-        .out_1_1 (d11),
-        .out_1_2 (d12),
-        .out_2_0 (d20),
-        .out_2_1 (d21),
-        .out_2_2 (d22),
         .input_ready(input_ready),
         .inputbuf_read_en(inputbuf_read_en)
     );
@@ -164,39 +132,24 @@ module conv33 #(
     //计算模块
     wire [OUT_WIDTH-1:0] result;
 
-    conv33_calc #(
+    conv11_calc #(
         .DATA_WIDTH(DATA_WIDTH),
         .MUL_WIDTH (MUL_WIDTH),
         .OUT_WIDTH (OUT_WIDTH)
     ) u_calc(
         .clk     (clk),
         .rst     (rst),
-        .conv33_en(conv33_en),
+        .conv11_en(conv11_en),
         .data_0_0(d00),
-        .data_0_1(d01),
-        .data_0_2(d02),
-        .data_1_0(d10),
-        .data_1_1(d11),
-        .data_1_2(d12),
-        .data_2_0(d20),
-        .data_2_1(d21),
-        .data_2_2(d22),
         .weight_0(w0),
-        .weight_1(w1),
-        .weight_2(w2),
-        .weight_3(w3),
-        .weight_4(w4),
-        .weight_5(w5),
-        .weight_6(w6),
-        .weight_7(w7),
-        .weight_8(w8),
         .bias    (bias),
+        .scale   (scale),
         .result  (result),
         .valid   (calc_valid)
     );
 
     //输出模块
-    conv33_output #(
+    conv11_output #(
         .OUT_WIDTH(OUT_WIDTH)
     ) u_output(
         .clk     (clk),


### PR DESCRIPTION
## Summary
- modify conv11 scripts to implement 1x1 convolution instead of 3x3
- keep existing data widths but streamline input and weight handling
- rename modules in conv11 folder

## Testing
- `verilator --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce5d422c08332b56e1ef77642f81a